### PR TITLE
feat: Add update and delete message endpoints with ownership validation

### DIFF
--- a/Controllers/messageContoller.js
+++ b/Controllers/messageContoller.js
@@ -52,4 +52,68 @@ export const getAllMessages = async (req, res) => {
   }
 };
 
+// Update message - only the user who created it can update
+export const updateMessage = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    // Find the message first to check ownership
+    const message = await Message.findById(id);
+
+    if (!message) {
+      throw new NotFoundError("Message not found");
+    }
+
+    // Check if the logged-in user is the creator of the message
+    if (message.createdBy.toString() !== req.user.userId) {
+      throw new BadRequestError("You are not authorized to update this message");
+    }
+
+    const updatedMessage = await Message.findByIdAndUpdate(id, req.body, {
+      new: true,
+      runValidators: true,
+    });
+
+    res.status(StatusCodes.OK).json({
+      msg: "Message updated successfully",
+      message: updatedMessage,
+    });
+  } catch (error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      msg: "Failed to update message",
+      error: error.message,
+    });
+  }
+};
+
+// Delete message - only the user who created it can delete
+export const deleteMessage = async (req, res) => {
+  try {
+    const { id } = req.params;
+    
+    // Find the message first to check ownership
+    const message = await Message.findById(id);
+
+    if (!message) {
+      throw new NotFoundError("Message not found");
+    }
+
+    // Check if the logged-in user is the creator of the message
+    if (message.createdBy.toString() !== req.user.userId) {
+      throw new BadRequestError("You are not authorized to delete this message");
+    }
+
+    await Message.findByIdAndDelete(id);
+
+    res.status(StatusCodes.OK).json({ msg: "Message deleted successfully" });
+  } catch (error) {
+    res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+      msg: "Failed to delete message",
+      error: error.message,
+    });
+  }
+};
+
+
+
 

--- a/Routes/messageRouter.js
+++ b/Routes/messageRouter.js
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import {createMessage, getAllMessages} from "../Controllers/messageContoller.js";
+import {createMessage, getAllMessages, updateMessage, deleteMessage} from "../Controllers/messageContoller.js";
 import { authenticateUser, authorizePermissions } from "../Middleware/authMiddleware.js";
 
 const router = Router();
@@ -15,5 +15,17 @@ router.get(
          authenticateUser, 
          authorizePermissions("user", "admin", "tutor"),
          getAllMessages);
+
+router.patch(
+    "/:id",
+     authenticateUser,
+     authorizePermissions("user"),
+     updateMessage);
+
+router.delete(
+    "/:id",
+     authenticateUser,
+     authorizePermissions("user"),
+     deleteMessage);
 
 export default router;


### PR DESCRIPTION
- Implemented updateMessage controller with creator-only authorization
- Implemented deleteMessage controller with creator-only authorization
- Added PATCH /api/messages/:id route for updating messages
- Added DELETE /api/messages/:id route for deleting messages
- Security: Only message creators can update or delete their own messages